### PR TITLE
consolidateBy exposure fixes

### DIFF
--- a/graphite_api/app.py
+++ b/graphite_api/app.py
@@ -379,7 +379,7 @@ def render():
         'startTime': request_options['startTime'],
         'endTime': request_options['endTime'],
         'data': [],
-        'consolidateBy': 'avg',
+        'consolidateBy': None,
     }
 
     if request_options['graphType'] == 'pie':
@@ -510,7 +510,7 @@ def evaluateTokens(requestContext, tokens):
     elif tokens.call:
         func = app.functions[tokens.call.funcname]
         if tokens.call.funcname == "consolidateBy":
-            requestContext['consolidateBy'] = tokens.call.args[1]
+            requestContext['consolidateBy'] = tokens.call.args[1][0]
         args = [evaluateTokens(requestContext,
                                arg) for arg in tokens.call.args]
         kwargs = dict([(kwarg.argname,

--- a/graphite_api/node.py
+++ b/graphite_api/node.py
@@ -6,7 +6,7 @@ class Node(object):
         self.name = path.split('.')[-1]
         self.local = True
         self.is_leaf = False
-        self.consolidateBy = 'avg'
+        self.consolidateBy = None
 
     def __repr__(self):
         return '<%s[%x]: %s>' % (self.__class__.__name__, id(self), self.path)


### PR DESCRIPTION
1) differentiate between not specified and specified by user, so that
   backends can handle these cases differently.
2) expose just the function name, not the list of args
