### PR TITLE
make multi tenancy optional. fix #16

### DIFF
--- a/graphite_api/app.py
+++ b/graphite_api/app.py
@@ -75,10 +75,13 @@ methods = ('GET', 'POST')
 # ensure the request is authenticated.
 @app.before_request
 def authenticate():
-    if 'x-org-id' in request.headers:
-        g.org = int(request.headers['x-org-id'])
+    if app.config['multi_tenant']:
+        if 'x-org-id' in request.headers:
+            g.org = int(request.headers['x-org-id'])
+        else:
+           return 'not authenticated', 403
     else:
-       return 'not authenticated', 403
+        g.org = 1
 
 # No-op routes, non-essential for creating dashboards
 @app.route('/dashboard/find', methods=methods)

--- a/graphite_api/config.py
+++ b/graphite_api/config.py
@@ -44,6 +44,7 @@ default_conf = {
     },
     'time_zone': get_localzone().zone,
     'admin_token': 'jk832sjksf9asdkvnngddfg8sfk',
+    'multi_tenant': False,
 
 }
 if default_conf['time_zone'] == 'local':  # tzlocal didn't find anything
@@ -148,6 +149,7 @@ def configure(app):
     logger.info("configured timezone", timezone=app.config['TIME_ZONE'])
 
     app.config['admin_token'] = config['admin_token']
+    app.config['multi_tenant'] = config['multi_tenant']
     
     
     if 'sentry_dsn' in config:


### PR DESCRIPTION
this way you can use graphite-api + graphite-metric tank in a single
tenant setup without having to require something like tsdb-gw
which has to authenticate on your behalf and set the x-org-id header
